### PR TITLE
build: pnpm-workspaceを削除

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,5 +7,8 @@
     "@commitlint/config-conventional": "19.8.1",
     "lefthook": "1.13.0",
     "npm-check-updates": "18.1.1"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": ["lefthook"]
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,0 @@
-onlyBuiltDependencies:
-  - lefthook


### PR DESCRIPTION
dependabotがpnpm-workspaceにpackagesフィールドがないとエラーになるため、pnpm-workspace.yamlを削除